### PR TITLE
feat: update external node version to 24.6.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ docker_compose_version: "v2.23.0"
 # Versions of External Node and 3rd party components
 traefik_version: 2.11
 postgres_version: 14
-external_node_version: 24.0.0
+external_node_version: 24.6.0
 external_node_raw_docker_tag: ""
 vmagent_version: 1.100.1
 cadvisor_version: 0.47.2


### PR DESCRIPTION
## What ❔

Updating default EN version to current upstream

## Why ❔

We should use latest upstream version as default

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
