### PR TITLE
feat(consensus): bumped inbound connections limit

### DIFF
--- a/templates/consensus_config.yaml.j2
+++ b/templates/consensus_config.yaml.j2
@@ -1,9 +1,10 @@
 server_addr: '0.0.0.0:3054'
 public_addr: '{{ ansible_default_ipv4.address }}:{{ consensus_port }}'
 max_payload_size: 5000000
-gossip_dynamic_inbound_limit: 100
-gossip_static_outbound:
-{% for item in consensus_outbound %}
-  - key: {{ item.key }}
-    addr: {{ item.addr }}
-{% endfor %}
+gossip_dynamic_inbound_limit: 200
+rpc_config:
+  get_block_rate:
+    burst: 5
+    refresh: # 0.2s
+      seconds: 0
+      nanos: 200000000


### PR DESCRIPTION
Same as https://github.com/matter-labs/gitops-kubernetes/pull/7108 for ENs running on hetzner. The default set of outbound connections is now advertised by the main node, so there is no need to configure is manually.